### PR TITLE
Fix ngrok workflow

### DIFF
--- a/.github/workflows/ngrok.yml
+++ b/.github/workflows/ngrok.yml
@@ -20,12 +20,12 @@ jobs:
         cd server && npm install
         cd ../public && npm install
         cd ..
+        npm install -g ngrok
 
     - name: Start backend and frontend
       run: |
-        cd server && npm start &
-        cd ../public && npm start &
-        cd ..
+        (cd server && node node_modules/nodemon/bin/nodemon.js index.js &)
+        (cd public && npm start &)
 
     - name: Run ngrok tunnels
       env:


### PR DESCRIPTION
## Summary
- install ngrok in CI
- use subshells for concurrent startup
- run nodemon directly when launching backend

## Testing
- `npm test --prefix public --silent` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c44fe8488332897cadad4bcc94bb