### PR TITLE
Fix CORS instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,19 @@ cd server
 npm install
 ```
 
-3. Run the App
+3. (Optional) Configure environment variables
+
+If the server is exposed via a public URL (for example using ngrok),
+create a `.env` file inside the `public` folder and set:
+
+```bash
+REACT_APP_CUSTOM_SERVER_URL=<your server url>
+```
+
+Ensure that `CUSTOM_CLIENT_URL` in `server/.env.local` points to the URL
+where the React application is served.
+
+4. Run the App
 
  Navigate to server directory and start the server
  ```bash

--- a/public/src/utils/APIRoutes.js
+++ b/public/src/utils/APIRoutes.js
@@ -1,4 +1,11 @@
-export const host = process.env.CUSTOM_SERVER_URL||"http://localhost:5000";
+// The API server can be customized by setting the environment variable
+// `REACT_APP_CUSTOM_SERVER_URL` when building the React application.
+// This allows the frontend to talk to a server exposed via a public URL
+// (for example when using ngrok).  Create a `.env` file in the `public`
+// directory with `REACT_APP_CUSTOM_SERVER_URL=<your server url>` if you
+// need to override the default localhost URL.
+export const host =
+  process.env.REACT_APP_CUSTOM_SERVER_URL || "http://localhost:5000";
 export const loginRoute = `${host}/api/auth/login`;
 export const registerRoute = `${host}/api/auth/register`;
 export const logoutRoute = `${host}/api/auth/logout`;


### PR DESCRIPTION
## Summary
- document how to customize the API server URL
- make `APIRoutes` use `REACT_APP_CUSTOM_SERVER_URL`

## Testing
- `npm test --prefix public`
- `npm test --prefix server` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6843124a46a0833292aa127b31e744c4