### PR TITLE
Fix localStorage checks to avoid null username error

### DIFF
--- a/public/src/components/ChatContainer.jsx
+++ b/public/src/components/ChatContainer.jsx
@@ -15,14 +15,16 @@ export default function ChatContainer({ currentChat, socket }) {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const data = JSON.parse(localStorage.getItem("chat-app-user"));
+        const storedUser = localStorage.getItem("chat-app-user");
+        if (!storedUser) return;
+        const data = JSON.parse(storedUser);
         const response = await axios.post(recieveMessageRoute, {
           from: data._id,
           to: currentChat._id,
         });
         setMessages(response.data);
       } catch (error) {
-        console.error('Error fetching data:', error);
+        console.error("Error fetching data:", error);
         // Optionally, handle error or show error message
       }
     };
@@ -35,18 +37,19 @@ export default function ChatContainer({ currentChat, socket }) {
   useEffect(() => {
     const getCurrentChat = async () => {
       if (currentChat) {
-        await JSON.parse(
-          localStorage.getItem("chat-app-user")
-        )._id;
+        const storedUser = localStorage.getItem("chat-app-user");
+        if (storedUser) {
+          await JSON.parse(storedUser)._id;
+        }
       }
     };
     getCurrentChat();
   }, [currentChat]);
 
   const handleSendMsg = async (msg) => {
-    const data = await JSON.parse(
-      localStorage.getItem("chat-app-user")
-    );
+    const storedUser = localStorage.getItem("chat-app-user");
+    if (!storedUser) return;
+    const data = await JSON.parse(storedUser);
     socket.current.emit("send-msg", {
       to: currentChat._id,
       from: data._id,

--- a/public/src/components/Contacts.jsx
+++ b/public/src/components/Contacts.jsx
@@ -10,9 +10,12 @@ export default function Contacts({ contacts, changeChat }) {
 
   useEffect(() => {
     const fetchData = async () => {
-      const data = await JSON.parse(localStorage.getItem("chat-app-user"));
-      setCurrentUserName(data.username);
-      setCurrentUserImage(data.avatarImage);
+      const storedUser = localStorage.getItem("chat-app-user");
+      if (storedUser) {
+        const data = await JSON.parse(storedUser);
+        setCurrentUserName(data.username);
+        setCurrentUserImage(data.avatarImage);
+      }
     };
 
     fetchData();

--- a/public/src/components/Logout.jsx
+++ b/public/src/components/Logout.jsx
@@ -9,9 +9,9 @@ export default function Logout() {
 
   
   const handleClick = async () => {
-    const id = await JSON.parse(
-      localStorage.getItem("chat-app-user")
-    )._id;
+    const storedUser = localStorage.getItem("chat-app-user");
+    if (!storedUser) return;
+    const id = await JSON.parse(storedUser)._id;
     const data = await axios.get(`${logoutRoute}/${id}`);
     if (data.status === 200) {
       localStorage.clear();

--- a/public/src/components/SetAvatar.jsx
+++ b/public/src/components/SetAvatar.jsx
@@ -36,7 +36,9 @@ export default function SetAvatar() {
     if (selectedAvatar === undefined) {
       toast.error("Please select an avatar", toastOptions);
     } else {
-      const user = await JSON.parse(localStorage.getItem("chat-app-user"));
+      const storedUser = localStorage.getItem("chat-app-user");
+      if (!storedUser) return;
+      const user = await JSON.parse(storedUser);
       const { data } = await axios.post(`${setAvatarRoute}/${user._id}`, {
         image: avatars[selectedAvatar],
       });

--- a/public/src/components/Welcome.jsx
+++ b/public/src/components/Welcome.jsx
@@ -6,13 +6,14 @@ export default function Welcome() {
 
   //fetching the username from local storage  
   useEffect(() => {
-    const fetchData = async ()=>{
-        const data=await JSON.parse(
-            localStorage.getItem("chat-app-user")
-          ).username  ;
-    setUserName(data);
-}
-fetchData();
+    const fetchData = async () => {
+      const storedUser = localStorage.getItem("chat-app-user");
+      if (storedUser) {
+        const data = await JSON.parse(storedUser);
+        setUserName(data.username);
+      }
+    };
+    fetchData();
   }, []);
 
 


### PR DESCRIPTION
## Summary
- prevent errors when user data isn't in localStorage
- guard parsing of `chat-app-user` in multiple components

## Testing
- `npm test --silent --prefix public -- --watchAll=false --passWithNoTests`
- `npm test --prefix server` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6845339fa66083328e116e9d5e071ec4