### PR TITLE
Fix null user crash

### DIFF
--- a/public/src/components/ChatContainer.jsx
+++ b/public/src/components/ChatContainer.jsx
@@ -6,6 +6,7 @@ import Logout from "./Logout";
 import { v4 as uuidv4 } from "uuid";
 import axios from "axios";
 import { sendMessageRoute, recieveMessageRoute } from "../utils/APIRoutes";
+import { getStoredUser } from "../utils/localStorageHelpers";
 
 export default function ChatContainer({ currentChat, socket }) {
   const [messages, setMessages] = useState([]);
@@ -15,9 +16,8 @@ export default function ChatContainer({ currentChat, socket }) {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const storedUser = localStorage.getItem("chat-app-user");
-        if (!storedUser) return;
-        const data = JSON.parse(storedUser);
+        const data = getStoredUser();
+        if (!data) return;
         const response = await axios.post(recieveMessageRoute, {
           from: data._id,
           to: currentChat._id,
@@ -37,9 +37,9 @@ export default function ChatContainer({ currentChat, socket }) {
   useEffect(() => {
     const getCurrentChat = async () => {
       if (currentChat) {
-        const storedUser = localStorage.getItem("chat-app-user");
-        if (storedUser) {
-          await JSON.parse(storedUser)._id;
+        const data = getStoredUser();
+        if (data) {
+          await data._id;
         }
       }
     };
@@ -47,9 +47,8 @@ export default function ChatContainer({ currentChat, socket }) {
   }, [currentChat]);
 
   const handleSendMsg = async (msg) => {
-    const storedUser = localStorage.getItem("chat-app-user");
-    if (!storedUser) return;
-    const data = await JSON.parse(storedUser);
+    const data = getStoredUser();
+    if (!data) return;
     socket.current.emit("send-msg", {
       to: currentChat._id,
       from: data._id,

--- a/public/src/components/Contacts.jsx
+++ b/public/src/components/Contacts.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 import Logo from "../assets/logo.svg";
+import { getStoredUser } from "../utils/localStorageHelpers";
 
 export default function Contacts({ contacts, changeChat }) {
   const [currentUserName, setCurrentUserName] = useState(undefined);
@@ -9,10 +10,9 @@ export default function Contacts({ contacts, changeChat }) {
 
 
   useEffect(() => {
-    const fetchData = async () => {
-      const storedUser = localStorage.getItem("chat-app-user");
-      if (storedUser) {
-        const data = await JSON.parse(storedUser);
+    const fetchData = () => {
+      const data = getStoredUser();
+      if (data) {
         setCurrentUserName(data.username);
         setCurrentUserImage(data.avatarImage);
       }

--- a/public/src/components/Logout.jsx
+++ b/public/src/components/Logout.jsx
@@ -4,14 +4,15 @@ import { BiPowerOff } from "react-icons/bi";
 import styled from "styled-components";
 import axios from "axios";
 import { logoutRoute } from "../utils/APIRoutes";
+import { getStoredUser } from "../utils/localStorageHelpers";
 export default function Logout() {
   const navigate = useNavigate();
 
   
   const handleClick = async () => {
-    const storedUser = localStorage.getItem("chat-app-user");
-    if (!storedUser) return;
-    const id = await JSON.parse(storedUser)._id;
+    const dataUser = getStoredUser();
+    if (!dataUser) return;
+    const id = dataUser._id;
     const data = await axios.get(`${logoutRoute}/${id}`);
     if (data.status === 200) {
       localStorage.clear();

--- a/public/src/components/SetAvatar.jsx
+++ b/public/src/components/SetAvatar.jsx
@@ -8,6 +8,7 @@ import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import { useNavigate } from "react-router-dom";
 import { setAvatarRoute } from "../utils/APIRoutes";
+import { getStoredUser } from "../utils/localStorageHelpers";
 
 export default function SetAvatar() {
   const navigate = useNavigate();
@@ -25,7 +26,7 @@ export default function SetAvatar() {
 
   useEffect(() => {
     const checkUser = async () => {
-      if (!localStorage.getItem("chat-app-user")) {
+      if (!getStoredUser()) {
         navigate("/login");
       }
     };
@@ -36,9 +37,8 @@ export default function SetAvatar() {
     if (selectedAvatar === undefined) {
       toast.error("Please select an avatar", toastOptions);
     } else {
-      const storedUser = localStorage.getItem("chat-app-user");
-      if (!storedUser) return;
-      const user = await JSON.parse(storedUser);
+      const user = getStoredUser();
+      if (!user) return;
       const { data } = await axios.post(`${setAvatarRoute}/${user._id}`, {
         image: avatars[selectedAvatar],
       });

--- a/public/src/components/Welcome.jsx
+++ b/public/src/components/Welcome.jsx
@@ -1,15 +1,15 @@
 import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 import Robot from "../assets/robot.gif";
+import { getStoredUser } from "../utils/localStorageHelpers";
 export default function Welcome() {
   const [userName, setUserName] = useState("");
 
   //fetching the username from local storage  
   useEffect(() => {
-    const fetchData = async () => {
-      const storedUser = localStorage.getItem("chat-app-user");
-      if (storedUser) {
-        const data = await JSON.parse(storedUser);
+    const fetchData = () => {
+      const data = getStoredUser();
+      if (data) {
         setUserName(data.username);
       }
     };

--- a/public/src/pages/Chat.jsx
+++ b/public/src/pages/Chat.jsx
@@ -7,6 +7,7 @@ import { allUsersRoute, host } from "../utils/APIRoutes";
 import ChatContainer from "../components/ChatContainer";
 import Contacts from "../components/Contacts";
 import Welcome from "../components/Welcome";
+import { getStoredUser } from "../utils/localStorageHelpers";
 
 export default function Chat() {
   const navigate = useNavigate();
@@ -25,19 +26,18 @@ export default function Chat() {
 
   //for fetching the user from local storage   
   useEffect(() => {
-    const checkLocalStorage = async () => {
-      const userItem = localStorage.getItem("chat-app-user");
+    const checkLocalStorage = () => {
+      const user = getStoredUser();
 
-      if (!userItem) {
+      if (!user) {
         //if user not found then navigate to the login page
         navigate("/login");
       } else {
         //else set the current user in usestate
-        const user = await JSON.parse(userItem);
         setCurrentUser(user);
       }
     };
-    //first form a function and call it dont write it in one go 
+    //first form a function and call it dont write it in one go
     checkLocalStorage();
   }, [navigate]);
 

--- a/public/src/utils/localStorageHelpers.js
+++ b/public/src/utils/localStorageHelpers.js
@@ -1,0 +1,13 @@
+export function getStoredUser() {
+  try {
+    const storedUser = localStorage.getItem("chat-app-user");
+    if (!storedUser) return null;
+    const parsed = JSON.parse(storedUser);
+    if (parsed && typeof parsed === "object") {
+      return parsed;
+    }
+  } catch (err) {
+    console.error("Failed to parse stored user", err);
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- add helper to safely parse `chat-app-user` from localStorage
- use helper in Contacts, ChatContainer, Logout, SetAvatar, Welcome and Chat page

## Testing
- `npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_684536195a088332a92b45e768eedbcf