### PR TITLE
Fix login redirect loop

### DIFF
--- a/client/src/components/ChatContainer.jsx
+++ b/client/src/components/ChatContainer.jsx
@@ -7,6 +7,8 @@ import { v4 as uuidv4 } from "uuid";
 import axios from "axios";
 import { sendMessageRoute, recieveMessageRoute } from "../utils/APIRoutes";
 
+const LOCAL_STORAGE_KEY = "chat-app-user";
+
 export default function ChatContainer({ currentChat, socket }) {
   const [messages, setMessages] = useState([]);
   const scrollRef = useRef();
@@ -15,7 +17,7 @@ export default function ChatContainer({ currentChat, socket }) {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const data = JSON.parse(localStorage.getItem(process.env.REACT_APP_LOCALHOST_KEY));
+        const data = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY));
         const response = await axios.post(recieveMessageRoute, {
           from: data._id,
           to: currentChat._id,
@@ -36,7 +38,7 @@ export default function ChatContainer({ currentChat, socket }) {
     const getCurrentChat = async () => {
       if (currentChat) {
         await JSON.parse(
-          localStorage.getItem(process.env.REACT_APP_LOCALHOST_KEY)
+          localStorage.getItem(LOCAL_STORAGE_KEY)
         )._id;
       }
     };
@@ -45,7 +47,7 @@ export default function ChatContainer({ currentChat, socket }) {
 
   const handleSendMsg = async (msg) => {
     const data = await JSON.parse(
-      localStorage.getItem(process.env.REACT_APP_LOCALHOST_KEY)
+      localStorage.getItem(LOCAL_STORAGE_KEY)
     );
     socket.current.emit("send-msg", {
       to: currentChat._id,

--- a/client/src/pages/Chat.jsx
+++ b/client/src/pages/Chat.jsx
@@ -1,16 +1,17 @@
 import React, { useEffect, useState, useRef } from "react";
 import axios from "axios";
-import { useNavigate, useLocation } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { io } from "socket.io-client";
 import styled from "styled-components";
 import { allUsersRoute, host } from "../utils/APIRoutes";
+
+const LOCAL_STORAGE_KEY = "chat-app-user";
 import ChatContainer from "../components/ChatContainer";
 import Contacts from "../components/Contacts";
 import Welcome from "../components/Welcome";
 
 export default function Chat() {
   const navigate = useNavigate();
-  const location = useLocation();
   const socket = useRef();
 
   const [contacts, setContacts] = useState([]);
@@ -19,19 +20,14 @@ export default function Chat() {
 
   // check auth & redirect once if needed
   useEffect(() => {
-    const userKey = process.env.REACT_APP_LOCALHOST_KEY;
-    const userItem = localStorage.getItem(userKey);
-    console.log("LOCALHOST_KEY:", process.env.REACT_APP_LOCALHOST_KEY);
-
+    const userItem = localStorage.getItem(LOCAL_STORAGE_KEY);
     if (!userItem) {
-      if (location.pathname !== "/login") {
-        navigate("/login", { replace: true });
-      }
+      navigate("/login", { replace: true });
     } else {
       const user = JSON.parse(userItem);
       setCurrentUser(user);
     }
-  }, [navigate, location.pathname]);
+  }, [navigate]);
 
   // socket setup
   useEffect(() => {


### PR DESCRIPTION
## Summary
- fix Chat auth check to avoid location-based loop
- replace environment-based local storage key with constant
- update ChatContainer to use same constant

## Testing
- `npm test` in `server` *(fails: no test specified)*
- `npm test --silent` in `client` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68458322fa408332a1f7f61bdfe1f9cd