### PR TITLE
Fix login redirect loop

### DIFF
--- a/client/src/components/ChatContainer.jsx
+++ b/client/src/components/ChatContainer.jsx
@@ -6,6 +6,7 @@ import Logout from "./Logout";
 import { v4 as uuidv4 } from "uuid";
 import axios from "axios";
 import { sendMessageRoute, recieveMessageRoute } from "../utils/APIRoutes";
+import { LOCAL_STORAGE_KEY } from "../utils/constants";
 
 export default function ChatContainer({ currentChat, socket }) {
   const [messages, setMessages] = useState([]);
@@ -15,7 +16,7 @@ export default function ChatContainer({ currentChat, socket }) {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const data = JSON.parse(localStorage.getItem(process.env.REACT_APP_LOCALHOST_KEY));
+        const data = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY));
         const response = await axios.post(recieveMessageRoute, {
           from: data._id,
           to: currentChat._id,
@@ -36,7 +37,7 @@ export default function ChatContainer({ currentChat, socket }) {
     const getCurrentChat = async () => {
       if (currentChat) {
         await JSON.parse(
-          localStorage.getItem(process.env.REACT_APP_LOCALHOST_KEY)
+          localStorage.getItem(LOCAL_STORAGE_KEY)
         )._id;
       }
     };
@@ -45,7 +46,7 @@ export default function ChatContainer({ currentChat, socket }) {
 
   const handleSendMsg = async (msg) => {
     const data = await JSON.parse(
-      localStorage.getItem(process.env.REACT_APP_LOCALHOST_KEY)
+      localStorage.getItem(LOCAL_STORAGE_KEY)
     );
     socket.current.emit("send-msg", {
       to: currentChat._id,

--- a/client/src/components/Contacts.jsx
+++ b/client/src/components/Contacts.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 import Logo from "../assets/logo.svg";
+import { LOCAL_STORAGE_KEY } from "../utils/constants";
 
 export default function Contacts({ contacts, changeChat }) {
   const [currentUserName, setCurrentUserName] = useState(undefined);
@@ -10,7 +11,7 @@ export default function Contacts({ contacts, changeChat }) {
 
   useEffect(() => {
     const fetchData = async () => {
-      const data = await JSON.parse(localStorage.getItem("chat-app-user"));
+      const data = await JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY));
       setCurrentUserName(data.username);
       setCurrentUserImage(data.avatarImage);
     };

--- a/client/src/components/Logout.jsx
+++ b/client/src/components/Logout.jsx
@@ -4,13 +4,14 @@ import { BiPowerOff } from "react-icons/bi";
 import styled from "styled-components";
 import axios from "axios";
 import { logoutRoute } from "../utils/APIRoutes";
+import { LOCAL_STORAGE_KEY } from "../utils/constants";
 export default function Logout() {
   const navigate = useNavigate();
 
   
   const handleClick = async () => {
     const id = await JSON.parse(
-      localStorage.getItem("chat-app-user")
+      localStorage.getItem(LOCAL_STORAGE_KEY)
     )._id;
     const data = await axios.get(`${logoutRoute}/${id}`);
     if (data.status === 200) {

--- a/client/src/components/SetAvatar.jsx
+++ b/client/src/components/SetAvatar.jsx
@@ -8,6 +8,7 @@ import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import { useNavigate } from "react-router-dom";
 import { setAvatarRoute } from "../utils/APIRoutes";
+import { LOCAL_STORAGE_KEY } from "../utils/constants";
 
 export default function SetAvatar() {
   const navigate = useNavigate();
@@ -25,7 +26,7 @@ export default function SetAvatar() {
 
   useEffect(() => {
     const checkUser = async () => {
-      if (!localStorage.getItem("chat-app-user")) {
+      if (!localStorage.getItem(LOCAL_STORAGE_KEY)) {
         navigate("/login");
       }
     };
@@ -36,7 +37,7 @@ export default function SetAvatar() {
     if (selectedAvatar === undefined) {
       toast.error("Please select an avatar", toastOptions);
     } else {
-      const user = await JSON.parse(localStorage.getItem("chat-app-user"));
+      const user = await JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY));
       const { data } = await axios.post(`${setAvatarRoute}/${user._id}`, {
         image: avatars[selectedAvatar],
       });
@@ -45,7 +46,7 @@ export default function SetAvatar() {
       if (data.isSet) {
         user.isAvatarImageSet = true;
         user.avatarImage = data.image;
-        localStorage.setItem("chat-app-user", JSON.stringify(user));
+        localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(user));
         navigate("/");
       } else {
         toast.error("Error setting avatar. Please try again.", toastOptions);

--- a/client/src/components/Welcome.jsx
+++ b/client/src/components/Welcome.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 import Robot from "../assets/robot.gif";
+import { LOCAL_STORAGE_KEY } from "../utils/constants";
 export default function Welcome() {
   const [userName, setUserName] = useState("");
 
@@ -8,7 +9,7 @@ export default function Welcome() {
   useEffect(() => {
     const fetchData = async ()=>{
         const data=await JSON.parse(
-            localStorage.getItem("chat-app-user")
+            localStorage.getItem(LOCAL_STORAGE_KEY)
           ).username  ;
     setUserName(data);
 }

--- a/client/src/pages/Chat.jsx
+++ b/client/src/pages/Chat.jsx
@@ -1,16 +1,16 @@
 import React, { useEffect, useState, useRef } from "react";
 import axios from "axios";
-import { useNavigate, useLocation } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { io } from "socket.io-client";
 import styled from "styled-components";
 import { allUsersRoute, host } from "../utils/APIRoutes";
 import ChatContainer from "../components/ChatContainer";
 import Contacts from "../components/Contacts";
 import Welcome from "../components/Welcome";
+import { LOCAL_STORAGE_KEY } from "../utils/constants";
 
 export default function Chat() {
   const navigate = useNavigate();
-  const location = useLocation();
   const socket = useRef();
 
   const [contacts, setContacts] = useState([]);
@@ -19,19 +19,14 @@ export default function Chat() {
 
   // check auth & redirect once if needed
   useEffect(() => {
-    const userKey = process.env.REACT_APP_LOCALHOST_KEY;
-    const userItem = localStorage.getItem(userKey);
-    console.log("LOCALHOST_KEY:", process.env.REACT_APP_LOCALHOST_KEY);
-
+    const userItem = localStorage.getItem(LOCAL_STORAGE_KEY);
     if (!userItem) {
-      if (location.pathname !== "/login") {
-        navigate("/login", { replace: true });
-      }
+      navigate("/login", { replace: true });
     } else {
       const user = JSON.parse(userItem);
       setCurrentUser(user);
     }
-  }, [navigate, location.pathname]);
+  }, [navigate]);
 
   // socket setup
   useEffect(() => {

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -6,6 +6,7 @@ import Logo from "../assets/logo.svg";
 import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import { loginRoute } from "../utils/APIRoutes";
+import { LOCAL_STORAGE_KEY } from "../utils/constants";
 
 export default function Login() {
   const navigate = useNavigate();
@@ -19,7 +20,7 @@ export default function Login() {
 
   };
   useEffect(() => {
-    if (localStorage.getItem("chat-app-user")) {
+    if (localStorage.getItem(LOCAL_STORAGE_KEY)) {
       navigate("/");
     }
   }, [navigate]);
@@ -53,7 +54,7 @@ export default function Login() {
       }
       if (data.status === true) {
         localStorage.setItem(
-          "chat-app-user",
+          LOCAL_STORAGE_KEY,
           JSON.stringify(data.user)
         );
 

--- a/client/src/pages/Register.jsx
+++ b/client/src/pages/Register.jsx
@@ -6,6 +6,7 @@ import { useNavigate, Link } from "react-router-dom";
 import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import { registerRoute } from "../utils/APIRoutes";
+import { LOCAL_STORAGE_KEY } from "../utils/constants";
 
 export default function Register() {
       //to navigate to the other page
@@ -29,10 +30,10 @@ export default function Register() {
       });
 
       useEffect(() => {
-        if (localStorage.getItem("chat-app-user")) {
+        if (localStorage.getItem(LOCAL_STORAGE_KEY)) {
           navigate("/");
         }
-      }, []);
+      }, [navigate]);
 
      const handleChange = (event) => {
     //this destructurises the input vaue and set the value to usestate hook
@@ -95,8 +96,8 @@ export default function Register() {
       if (data.status === true) {
         //storing our data in local storage 
         localStorage.setItem(
-          "chat-app-user",
-          //data converting into json string bcz browser storage only stores strings 
+          LOCAL_STORAGE_KEY,
+          //data converting into json string bcz browser storage only stores strings
           JSON.stringify(data.user)
         );
         //this nevigates to the chat container 

--- a/client/src/utils/constants.js
+++ b/client/src/utils/constants.js
@@ -1,0 +1,1 @@
+export const LOCAL_STORAGE_KEY = "chat-app-user";


### PR DESCRIPTION
## Summary
- fix Chat auth check to avoid location-based loop
- replace environment-based local storage key with constant
- update ChatContainer to use same constant
- share key across components and reorder imports

## Testing
- `npm test` in `server` *(fails: no test specified)*
- `npm test --silent` in `client` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68458322fa408332a1f7f61bdfe1f9cd