### PR TITLE
Fix logout visibility when no chat selected

### DIFF
--- a/client/src/components/Contacts.jsx
+++ b/client/src/components/Contacts.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 import Logo from "../assets/logo.svg";
 import { LOCAL_STORAGE_KEY } from "../utils/constants";
+import Logout from "./Logout";
 
 export default function Contacts({ contacts, changeChat }) {
   const [currentUserName, setCurrentUserName] = useState(undefined);
@@ -67,6 +68,7 @@ export default function Contacts({ contacts, changeChat }) {
             <div className="username">
               <h2>{currentUserName}</h2>
             </div>
+            <Logout />
           </div>
         </Container>
       )}


### PR DESCRIPTION
## Summary
- import Logout component into Contacts
- render Logout button in the current-user section

## Testing
- `npm test --silent --runTestsByPath` *(fails: Module._resolveFilename error)*

------
https://chatgpt.com/codex/tasks/task_e_6845a8fecc988332a177f116fe0be626