### PR TITLE
Fix lint warnings in chat components

### DIFF
--- a/client/src/components/ChatContainer.jsx
+++ b/client/src/components/ChatContainer.jsx
@@ -66,13 +66,14 @@ export default function ChatContainer({ currentChat, socket }) {
 
   useEffect(() => {
     if (socket.current) {
-      socket.current.on("msg-receive", (msg) => {
+      const currentSocket = socket.current;
+      currentSocket.on("msg-receive", (msg) => {
         setArrivalMessage({ fromSelf: false, message: msg });
       });
 
       // Clean up the event listener when the component unmounts
       return () => {
-        socket.current.off("msg-receive");
+        currentSocket.off("msg-receive");
       };
     }
   }, [socket]);


### PR DESCRIPTION
## Summary
- maintain stable socket ref in cleanup function

## Testing
- `npm test -- --passWithNoTests` in `client`
- `npm test` in `server` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6845aba06ce48332b3e858d018155f52