### PR TITLE
Fix contacts map crash

### DIFF
--- a/client/src/components/Contacts.jsx
+++ b/client/src/components/Contacts.jsx
@@ -36,7 +36,8 @@ export default function Contacts({ contacts, changeChat }) {
             <h3>nexchat</h3>
           </div>
           <div className="contacts">
-            {contacts.map((contact, index) => {
+            {Array.isArray(contacts) &&
+              contacts.map((contact, index) => {
               return (
                 <div
                   key={contact._id}

--- a/client/src/pages/Chat.jsx
+++ b/client/src/pages/Chat.jsx
@@ -86,7 +86,7 @@ export default function Chat() {
         const { data } = await axios.get(
           `${allUsersRoute}/${currentUser._id}`
         );
-        if (!data) throw new Error("No contact data");
+        if (!data || !Array.isArray(data)) throw new Error("No contact data");
         setContacts(data);
       } catch (err) {
         console.warn("Contact fetch failed, logging out:", err);


### PR DESCRIPTION
## Summary
- guard against `contacts` not being an array in `Contacts`
- validate response array in `Chat` before updating state

## Testing
- `npm test --silent --forceExit --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845af0f564083328d1d54e0b2af6f4b