### PR TITLE
Fix CORS configuration and deployment path

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,24 +30,27 @@ cd chat-app
  ```
 2. Install the necessary dependencies:
 ```bash
-cd public
+cd client
 npm install
-cd ..
-cd server
+cd ../server
 npm install
 ```
 
-3. Run the App
+3. Configure environment variables. Copy `.env.example` to `.env` in both
+   the `client` and `server` folders and update the URLs to match your
+   deployment or testing environment.
 
- Navigate to server directory and start the server
- ```bash
+4. Run the App
+
+Navigate to server directory and start the server
+```bash
 cd server
 npm start
 ```
 
- Navigate to public directory and start the application
+Navigate to client directory and start the application
 ```bash
-cd public
+cd ../client
 npm start
 ```
 

--- a/server/index.js
+++ b/server/index.js
@@ -14,10 +14,19 @@ const path =require("path");
 require("dotenv").config();
 
 
-//middlewares used 
+//middlewares used
+const allowedOrigins = process.env.ALLOWED_ORIGINS
+  ? process.env.ALLOWED_ORIGINS.split(',')
+  : [process.env.REACT_APP_CUSTOM_CLIENT_URL || "http://localhost:3000"];
+
 app.use(
   cors({
-    origin: [process.env.REACT_APP_CUSTOM_CLIENT_URL || "http://localhost:3000"],
+    origin: (origin, callback) => {
+      if (!origin || allowedOrigins.indexOf(origin) !== -1) {
+        return callback(null, true);
+      }
+      return callback(new Error("Not allowed by CORS"));
+    },
     credentials: true,
   })
 );
@@ -53,11 +62,12 @@ app.use("/api/messages", messageRoutes);
 
 //******************deployment********************/
 const __dirname1 = path.resolve();
-  app.use(express.static(path.join(__dirname1,'/public/build')));
+  // serve React build from client/build when deployed
+  app.use(express.static(path.join(__dirname1, "client", "build")));
 
 
   app.get('*',(req,res)=>{
-    res.sendFile(path.join(__dirname1,"public","build","index.html"));
+    res.sendFile(path.join(__dirname1,"client","build","index.html"));
   })
 
 //******************deployment********************/


### PR DESCRIPTION
## Summary
- allow multiple CORS origins configured through environment variable
- serve React build from `client/build`
- update setup instructions in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845c70451488332a136a3fa1546285b