### PR TITLE
Fix incorrect static path for production

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -61,14 +61,19 @@ app.use("/api/messages", messageRoutes);
 
 
 //******************deployment********************/
-const __dirname1 = path.resolve();
-  // serve React build from client/build when deployed
-  app.use(express.static(path.join(__dirname1, "client", "build")));
+// Resolve the path to the React build directory correctly. When the server is
+// started from the `server` folder, `path.resolve()` points to that folder,
+// leaving the build assets unresolved. Using `__dirname` and navigating one
+// level up ensures the `client/build` directory is found regardless of the
+// working directory.
+const clientBuildPath = path.join(__dirname, "..", "client", "build");
 
+// Serve React build from client/build when deployed
+app.use(express.static(clientBuildPath));
 
-  app.get('*',(req,res)=>{
-    res.sendFile(path.join(__dirname1,"client","build","index.html"));
-  })
+app.get('*', (_req, res) => {
+  res.sendFile(path.join(clientBuildPath, "index.html"));
+});
 
 //******************deployment********************/
 


### PR DESCRIPTION
## Summary
- resolve the correct path to the React build directory
- serve static files and index.html from the proper location

## Testing
- `npm test` in `server`
- `npm test --silent` in `client` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ce5b2aac8332a20510c18d1f24a0