### PR TITLE
Use wildcard cors

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -15,18 +15,9 @@ require("dotenv").config();
 
 
 //middlewares used
-const allowedOrigins = process.env.ALLOWED_ORIGINS
-  ? process.env.ALLOWED_ORIGINS.split(',')
-  : [process.env.REACT_APP_CUSTOM_CLIENT_URL || "http://localhost:3000"];
-
 app.use(
   cors({
-    origin: (origin, callback) => {
-      if (!origin || allowedOrigins.indexOf(origin) !== -1) {
-        return callback(null, true);
-      }
-      return callback(new Error("Not allowed by CORS"));
-    },
+    origin: "*",
     credentials: true,
   })
 );
@@ -85,7 +76,7 @@ const server = app.listen(PORT, () =>
 
 const io = socket(server, {
   cors: {
-    origin: [process.env.REACT_APP_CUSTOM_CLIENT_URL||"http://localhost:3000"],
+    origin: "*",
     credentials: true,
   },
 });


### PR DESCRIPTION
## Summary
- allow all origins by using wildcard when enabling CORS
- allow Socket.IO to accept connections from any origin

## Testing
- `node server/index.js` *(fails: Cannot find module 'side-channel-list')*
- `npm start` in server *(fails: nodemon Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6845da71b06883329dc74fde856c10cb