### PR TITLE
Fix CORS settings for external clients

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -15,9 +15,12 @@ require("dotenv").config();
 
 
 //middlewares used
+// Use CORS to allow requests from any origin while supporting credentials.
+// Setting `origin: true` reflects the request origin and is compatible with
+// `credentials: true` without violating the CORS specification.
 app.use(
   cors({
-    origin: "*",
+    origin: true,
     credentials: true,
   })
 );
@@ -80,7 +83,8 @@ const server = app.listen(PORT, () =>
 
 const io = socket(server, {
   cors: {
-    origin: "*",
+    // Reflect the request origin for Socket.IO connections as well
+    origin: true,
     credentials: true,
   },
 });


### PR DESCRIPTION
## Summary
- allow CORS requests from any origin when credentials are included
- apply same policy for Socket.IO

## Testing
- `npm test` in server (fails: `Error: no test specified`)
- `npm test` in client

------
https://chatgpt.com/codex/tasks/task_e_68468047f1308332bd1e710a944e1ae4